### PR TITLE
Slightly change BingoParty documentation link

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -387,7 +387,9 @@ If a BingoParty blocker is not working, try running &a/p list&r.`)
         placeholder: "GitHub"
     })
     openBPDocumentation() {
-        java.awt.Desktop.getDesktop().browse(new java.net.URL('https://github.com/aphased/BingoPartyCommands').toURI())
+        java.awt.Desktop.getDesktop().browse(new java.net.URL(
+            'https://github.com/aphased/BingoPartyCommands?tab=readme-ov-file#bingopartycommands'
+        ).toURI())
     }
   
     // Splasher


### PR DESCRIPTION
… so that it begins at the start of the BingoPartyCommands repo's README
file instead of at the very top.

It's basically a small QOL change, and the overall target of the link remains
the same with this.

As discussed before here: https://discord.com/channels/1163947833402085439/1270051267619848232/1270069180850372682