### PR TITLE
Add party join command aliases

### DIFF
--- a/commands/centuryCakeIsland.js
+++ b/commands/centuryCakeIsland.js
@@ -9,5 +9,5 @@ register("command", () => {
         ChatLib.chat(`${constants.PREFIX}&aDefaulting to BingoSplasher.`)
         name = "BingoSplasher"
     }
-    ChatLib.say(`/visit ${name}`)
+    ChatLib.command(`visit ${name}`)
 }).setCommandName("cake").setAliases("cakes")

--- a/commands/joinParty.js
+++ b/commands/joinParty.js
@@ -1,0 +1,10 @@
+import settings from "../settings";
+import constants from "../utils/constants";
+import Party from "../utils/Party"
+
+register("command", () => {
+  ChatLib.chat(`${constants.PREFIX}&aJoining Bingo party.`);
+  ChatLib.command(`p join ${Party.getBotIGN()}`);
+})
+  .setCommandName("pb")
+  .setAliases(settings().partyJoinAlias);

--- a/features/bingo/achievements.js
+++ b/features/bingo/achievements.js
@@ -13,8 +13,8 @@ register("chat", (event) => {
         ChatLib.chat(`${constants.PREFIX}&aAchievement copied to clipboard!`)
     }
     if (settings().autoSendAchievementsInParty) {
-        if (Party.inParty) ChatLib.say(`/pc ${event}`)
+        if (Party.inParty) ChatLib.command(`pc ${event}`)
     }
-    if (settings().autoSendAchievementsInGuild) ChatLib.say(`/gc ${event}`)
+    if (settings().autoSendAchievementsInGuild) ChatLib.command(`gc ${event}`)
 
 }).setCriteria(regex)

--- a/features/party/bingoPartyCommandConverter.js
+++ b/features/party/bingoPartyCommandConverter.js
@@ -97,8 +97,8 @@ register("messageSent", (message, event) => {
     // check if a random string should be added
     let newMessage = args.slice(1).join(' ') // the slice removes /p
     if (settings().bingoPartyCommandRandomString) newMessage = Party.addRandomString(newMessage)
-    const command = `/msg ${Party.getBotIGN()} !p ${newMessage}`
+    const command = `msg ${Party.getBotIGN()} !p ${newMessage}`
 
     cancel(event)
-    ChatLib.say(command)
+    ChatLib.command(command)
 })

--- a/settings.js
+++ b/settings.js
@@ -722,6 +722,16 @@ const config = new DefaultConfig("BingoPlus", "data/settings.json")
     subcategory: ""
 })
 
+.addTextInput({
+    category: "Commands",
+    configName: "partyJoinAlias",
+    title: "Bingo Party Join Alias",
+    description: "Runs &e/p join IGN&r using the bot IGN defined earlier.\nDefault command alias is &e/pb&r, you can define additional aliases below.",
+    value: "pjoinbp",
+    placeHolder: "pb",
+    subcategory: ""
+})
+
 // Dev
 
 .addTextParagraph({


### PR DESCRIPTION
(and some light codebase cleanup)

This does not attempt to do anything with `.unregister()`, so users will have to reload ChatTriggers after defining new aliases.
Wasn't sure how to best describe that in the settings, though, so you will probably have to add a phrase for that.